### PR TITLE
Adding the option to toggle a format file on or off.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 
 .snakemake/
 workup/
+assets/

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ However, the pipeline directory can also be kept separate and used repeatedly on
    - `max_size`: maximum count of deduplicated genomic DNA reads in a cluster for that cluster to be to be assigned to the corresponding antibody target; this criteria is intersected (AND) with the `proportion` and `max_size` criteria
    - `merge_samples`: [boolean value](https://yaml.org/type/bool.html) indicating whether to merge cluster files and target-specific BAM files across samples
    - `binsize`: integer specifying bigWig binsize; set to `false` to skip bigWig generation. Only relevant if generate_splitbams and merge_samples are both `true`.
-   - `toggle_format_on`: indicating whether to use format file(#format-txt) to validate barcode position strictly. Default is true.
+   - `toggle_format_on`: indicating whether to use [format file](#format-txt) to validate barcode position strictly. Default is true.
 
 2. <a name="samples-json">`samples.json`</a>: JSON file with the location of FASTQ files (read1, read2) to process.
    - [`config.yaml`](#config-yaml) key to specify the path to this file: `samples`

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ However, the pipeline directory can also be kept separate and used repeatedly on
    - `max_size`: maximum count of deduplicated genomic DNA reads in a cluster for that cluster to be to be assigned to the corresponding antibody target; this criteria is intersected (AND) with the `proportion` and `max_size` criteria
    - `merge_samples`: [boolean value](https://yaml.org/type/bool.html) indicating whether to merge cluster files and target-specific BAM files across samples
    - `binsize`: integer specifying bigWig binsize; set to `false` to skip bigWig generation. Only relevant if generate_splitbams and merge_samples are both `true`.
+   - `toggle_format_on`: indicating whether to use format file(#format-txt) to validate barcode position strictly. Default is true.
 
 2. <a name="samples-json">`samples.json`</a>: JSON file with the location of FASTQ files (read1, read2) to process.
    - [`config.yaml`](#config-yaml) key to specify the path to this file: `samples`

--- a/Snakefile
+++ b/Snakefile
@@ -67,12 +67,17 @@ except:
     bid_config = "config.txt"
     print('Config "bID" not specified, looking for config at:', bid_config, file=sys.stderr)
 
-try:
-    formatfile = config["format"]
-    print("Using split-pool format file: ", formatfile, file=sys.stderr)
-except:
-    formatfile = "format.txt"
-    print("Format file not specified, looking for file at:", formatfile, file=sys.stderr)
+toggle_format_on = config.get("toggle_format_on", True)
+if toggle_format_on:
+    try:
+        formatfile = config["format"]
+        print("Using split-pool format file: ", formatfile, file=sys.stderr)
+    except:
+        formatfile = "format.txt"
+        print("Format file not specified, looking for file at:", formatfile, file=sys.stderr)
+elif not toggle_format_on:
+    print("Will not use format file to validate positions.", file=sys.stderr)
+    toggle_format_on = False
 
 try:
     num_tags = int(config["num_tags"])
@@ -563,7 +568,7 @@ rule split_bpm_dpm:
        conda_env
     shell:
         '''
-        python "{split_bpm_dpm}" --r1 "{input}" --format "{formatfile}" &> "{log}"
+        python "{split_bpm_dpm}" --r1 "{input}" --format "{formatfile}" --toggle_format_on "{toggle_format_on}" &> "{log}"
         '''
 
 ##############################################################################

--- a/config.yaml
+++ b/config.yaml
@@ -11,13 +11,13 @@ samples: "example_samples.json"
 # Scripts directory
 scripts_dir: "scripts/"
 # Output directory
-output_dir: ""
+output_dir: "temp_workup/"
 # Temporary directory
 temp_dir: "/central/scratch/"
 
 # Conda environment: either a path to a conda environment YAML file ("*.yml" or "*.yaml")
 # or the name of an existing conda environment
-conda_env: "envs/chipdip.yaml"
+conda_env: "chipdip"
 
 # Path to chromosome name map file
 path_chrom_map: "chrom_map.txt"
@@ -53,3 +53,7 @@ merge_samples: true
 # - only relevant if generate_splitbams and merge_samples are both true
 # - Set to false to skip BigWig generation
 binsize: 1000
+
+# Option to not use a format file, which is used for strict barcode position validation
+# Default is true.
+toggle_format_on: true

--- a/config.yaml
+++ b/config.yaml
@@ -11,13 +11,13 @@ samples: "example_samples.json"
 # Scripts directory
 scripts_dir: "scripts/"
 # Output directory
-output_dir: "temp_workup/"
+output_dir: ""
 # Temporary directory
 temp_dir: "/central/scratch/"
 
 # Conda environment: either a path to a conda environment YAML file ("*.yml" or "*.yaml")
 # or the name of an existing conda environment
-conda_env: "chipdip"
+conda_env: "envs/chipdip.yaml"
 
 # Path to chromosome name map file
 path_chrom_map: "chrom_map.txt"


### PR DESCRIPTION
Adding option `toggle_format_on` in `config.yaml` so that users have the option to not use `format.txt` to strictly validate barcode position.